### PR TITLE
Remove deprecated `java.level` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
   <url>https://wiki.jenkins-ci.org/display/JENKINS/OctoPerf+Plugin</url>
 
   <properties>
-    <java.level>8</java.level>
     <commons.compress.version>1.21</commons.compress.version>
     <commons.lang3.version>3.12.0</commons.lang3.version>
     <commons.io.version>2.11.0</commons.io.version>


### PR DESCRIPTION
The `java.level` property was deprecated in [plugin parent POM 4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) and should be removed from this plugin's POM. In the future this warning will be changed to an error and will break the build. See https://github.com/jenkinsci/plugin-pom/pull/522 for details.